### PR TITLE
PR: Allow setting up the user config directory through the use of an os envrionment variable

### DIFF
--- a/appconfigs/base.py
+++ b/appconfigs/base.py
@@ -6,6 +6,7 @@
 # -----------------------------------------------------------------------------
 
 # ---- Standard library imports
+import os
 import os.path as osp
 
 # ---- Third party library imports
@@ -29,5 +30,7 @@ def get_config_dir(appname, appauthor=False):
     :return: Return full path to the user-specific config dir for
         this application.
     """
-    dirs = AppDirs(appname, appauthor=appauthor)
-    return dirs.user_config_dir
+    config_dir = (os.environ.get(appname.upper() + '_DIR') or
+                  AppDirs(appname, appauthor=appauthor).user_config_dir)
+
+    return config_dir

--- a/appconfigs/base.py
+++ b/appconfigs/base.py
@@ -14,7 +14,14 @@ from appdirs import AppDirs
 
 
 def get_home_dir():
-    """Return user home directory."""
+    """
+    Return user home directory.
+
+    Returns
+    -------
+    str
+        The full path to the user home directory.
+    """
     return osp.expanduser('~')
 
 

--- a/appconfigs/base.py
+++ b/appconfigs/base.py
@@ -8,6 +8,7 @@
 # ---- Standard library imports
 import os
 import os.path as osp
+from typing import Union
 
 # ---- Third party library imports
 from appdirs import AppDirs
@@ -25,7 +26,7 @@ def get_home_dir():
     return osp.expanduser('~')
 
 
-def get_config_dir(appname: str, appauthor: bool = False) -> str:
+def get_config_dir(appname: str, appauthor: Union[str, bool] = False) -> str:
     """
     Get and return the application config directory.
 
@@ -33,7 +34,7 @@ def get_config_dir(appname: str, appauthor: bool = False) -> str:
     ----------
     appname: str
         The name of the application for which the config directory is fetched.
-    appauthor: str
+    appauthor: str, bool
         The name of the author or distributing body for this application
         (only used on Windows). Typically it is the owning company name.
         You may pass False to disable it.

--- a/appconfigs/base.py
+++ b/appconfigs/base.py
@@ -18,17 +18,23 @@ def get_home_dir():
     return osp.expanduser('~')
 
 
-def get_config_dir(appname, appauthor=False):
+def get_config_dir(appname: str, appauthor: bool = False) -> str:
     """
     Get and return the application config directory.
 
-    :type appname: str
-    :param appname: Application name.
-    :param appauthor: Application author. By default, this value is set
-        to False.
-    :rtype: str
-    :return: Return full path to the user-specific config dir for
-        this application.
+    Parameters
+    ----------
+    appname: str
+        The name of the application for which the config directory is fetched.
+    appauthor: str
+        The name of the author or distributing body for this application
+        (only used on Windows). Typically it is the owning company name.
+        You may pass False to disable it.
+
+    Returns
+    -------
+    str
+     The full path to the user-specific config dir for this application.
     """
     config_dir = (os.environ.get(appname.upper() + '_DIR') or
                   AppDirs(appname, appauthor=appauthor).user_config_dir)

--- a/appconfigs/tests/test_base.py
+++ b/appconfigs/tests/test_base.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright © Jean-Sébastien Gosselin
+# Licensed under the terms of the MIT License
+# (https://github.com/jnsebgosselin/appconfigs)
+# -----------------------------------------------------------------------------
+
+# ---- Standard imports
+import os
+import os.path as osp
+
+# ---- Third party imports
+import pytest
+
+# ---- Local imports
+from appconfigs.base import get_config_dir
+
+APPNAME = 'appconfigs_base_test'
+
+
+# =============================================================================
+# ---- Tests
+# =============================================================================
+@pytest.mark.parametrize("appauthor", [False, 'john_doe'])
+def test_get_config_dir_default(appauthor):
+    """
+    Test that the path returned by get_config_dir has the correct basename
+    and takes into account the value passed for the appauthor on Windows.
+    """
+    config_dir = get_config_dir(APPNAME, appauthor)
+
+    assert config_dir
+    assert not osp.exists(config_dir)
+    assert osp.basename(config_dir) == APPNAME
+    if appauthor and os.name == 'nt':
+        assert osp.basename(osp.dirname(config_dir)) == appauthor
+
+
+def test_get_config_dir_environ_var(tmpdir):
+    """
+    Test that the get_config_dir returns the path defined in the os
+    environment variable when it exists for the specified application.
+    """
+    os.environ[APPNAME.upper() + '_DIR'] = str(tmpdir)
+
+    config_dir = get_config_dir(APPNAME)
+    assert osp.samefile(config_dir, str(tmpdir))
+
+
+if __name__ == "__main__":
+    pytest.main(['-x', osp.basename(__file__), '-vv', '-rw', '-s'])

--- a/appconfigs/tests/test_userconfig.py
+++ b/appconfigs/tests/test_userconfig.py
@@ -20,7 +20,9 @@ NAME = 'user_config_tests'
 CONF_VERSION = '0.1.0'
 
 
+# =============================================================================
 # ---- Pytest fixtures
+# =============================================================================
 @pytest.fixture
 def configdir(tmpdir):
     return osp.join(str(tmpdir), 'UserConfigTests')
@@ -36,7 +38,7 @@ def defaults():
               'option#5': True,
               'option#6': ['value', 22, 24.567, True],
               'option#7': ('value', 22, 24.567, True),
-              'option#8': {'suboption': ('value',  24.567)},
+              'option#8': {'suboption': ('value', 24.567)},
               }),
             ('section#1',
              {'option#1': 123.456,
@@ -44,7 +46,9 @@ def defaults():
               })]
 
 
+# =============================================================================
 # ---- Tests
+# =============================================================================
 @pytest.mark.parametrize("backup_value", [True, False])
 def test_files_creation(configdir, backup_value, defaults):
     """


### PR DESCRIPTION
The `get_config_dir` function in the `base` module will first check if an environment variable is defined for the user config directory of the application before getting the default directory for the provided application name and author.

The `get_config_dir` is looking for an environment variable that corresponds to the name of the application in caps followed by `'_DIR'`. So for example, the os environment variable for an application named `my_application` would be `MY_APPLICATION_DIR`.